### PR TITLE
Feature/hide no image config setting

### DIFF
--- a/src/config.php
+++ b/src/config.php
@@ -23,6 +23,20 @@
  */
 
 return [
+	// Plugin options
+	'options' => [
+		// Whether or not to show the "save for later" button
+		'enableSaveForLater' => false, // true|false
+
+		// Whether or not to show the shipping estimator
+		'enableEstimatedShipping' => false, // true|false
+
+		// Whether or not to show the free shipping message
+		'enableFreeShippingMessage' => false, // true|false
+
+		// Whether or not to show the "No Image" placeholder images
+		'enablePlaceholderImages' => false,
+	],
 	// Branding Settings
 	'branding' => [
 		// The brand primary custom color in HEX color

--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -9,6 +9,13 @@ use craft\base\Model;
  */
 class Settings extends Model
 {
+	public array $options = [
+		'enableSaveForLater' => false,
+		'enableEstimatedShipping' => false,
+		'enableFreeShippingMessage' => false,
+		'enablePlaceholderImages' => false,
+	];
+
 	public array $branding = [
 		'color' => '#1F2937',
 		'font' => 'Rubik',

--- a/src/services/Checkout.php
+++ b/src/services/Checkout.php
@@ -26,6 +26,15 @@ use yii\base\InvalidConfigException;
 class Checkout extends Component
 {
 	/*
+	 * Gets the options settings array
+	 */
+	public function options(): array
+	{
+		$settings = FosterCheckout::getInstance()->getSettings();
+		return $settings->options;
+	}
+
+	/*
 	 * Gets the branding settings array
 	 */
 	public function branding(): array

--- a/src/templates/_components/app/line-item-cart.twig
+++ b/src/templates/_components/app/line-item-cart.twig
@@ -29,7 +29,7 @@
 		<div class="w-[80px] min-w-[80px] max-w-[80px] md:w-[200px] md:min-w-[200px] md:max-w-[200px] flex-grow">
 			<figure class="rounded-lg overflow-hidden min-w-full">
 				<img
-					src="{{ imageUrl ?? ('https://placehold.co/200x200?text=' ~ 'No Image'|t('foster-checkout')|replace({ ' ': '+' })) }}"
+					src="{{ imageUrl ?? ('https://placehold.co/200x200?text=' ~ 'No Image'|t('foster-checkout')|split(' ')|join('+')) }}"
 					srcset="{{ imageUrl ? imageSrcSet : '' }}"
 					sizes="(min-width: 768px) 200px, 80px"
 					width="200"

--- a/src/templates/_components/app/line-item-cart.twig
+++ b/src/templates/_components/app/line-item-cart.twig
@@ -22,22 +22,24 @@
 
 <article
 	v-scope="LineItem({ id: {{ lineItem.id }}, qty: {{ lineItem.qty }}, min: {{ minQty ?? 0 }}, max: {{ maxQty ?? 0 }}, stock: {{ stock }}, unlimitedStock: {{ unlimitedStock }}, lineSubtotal: '{{ lineSubtotal }}', showErrorMaxMessage: false, showErrorMinMessage: false, showErrorStockMessage: false })"
-	class="flex justify-start items-stretch gap-5 p-5 bg-gray-200 rounded-xl"
+	class="flex justify-between items-stretch gap-5 p-5 bg-gray-200 rounded-xl"
 >
 
-	<div class="w-[80px] min-w-[80px] max-w-[80px] md:w-[200px] md:min-w-[200px] md:max-w-[200px] flex-grow">
-		<figure class="rounded-lg overflow-hidden min-w-full">
-			<img
-				src="{{ imageUrl ?? 'https://placehold.co/200x200?text=No+Image' }}"
-				srcset="{{ imageUrl ? imageSrcSet : '' }}"
-				sizes="(min-width: 768px) 200px, 80px"
-				width="200"
-				height="200"
-				class="min-w-full"
-				alt="{{ 'Image of'|t('foster-checkout') ~ ' ' ~ lineItem.description }}"
-			/>
-		</figure>
-	</div>
+	{% if imageUrl or craft.checkout.options.enablePlaceholderImages %}
+		<div class="w-[80px] min-w-[80px] max-w-[80px] md:w-[200px] md:min-w-[200px] md:max-w-[200px] flex-grow">
+			<figure class="rounded-lg overflow-hidden min-w-full">
+				<img
+					src="{{ imageUrl ?? ('https://placehold.co/200x200?text=' ~ 'No Image'|t('foster-checkout')|replace({ ' ': '+' })) }}"
+					srcset="{{ imageUrl ? imageSrcSet : '' }}"
+					sizes="(min-width: 768px) 200px, 80px"
+					width="200"
+					height="200"
+					class="min-w-full"
+					alt="{{ 'Image of'|t('foster-checkout') ~ ' ' ~ lineItem.description }}"
+				/>
+			</figure>
+		</div>
+	{% endif %}
 
 	<div class="flex flex-col justify-between items-stretch gap-10 flex-grow">
 

--- a/src/templates/_components/app/line-item-checkout.twig
+++ b/src/templates/_components/app/line-item-checkout.twig
@@ -11,18 +11,20 @@
 	{% set imageUrl = previewImage.getUrl(preview) %}
 {% endif %}
 
-<article class="flex justify-start items-stretch gap-4 p-4 bg-gray-200 rounded-xl">
+<article class="flex justify-between items-stretch gap-4 p-4 bg-gray-200 rounded-xl">
 
-	<div class="w-[70px] min-w-[70px]">
-		<figure class="rounded-lg overflow-hidden">
-			<img
-				src="{{ imageUrl ?? 'https://placehold.co/70x70?text=No+Image' }}"
-				width="70"
-				height="70"
-				alt="{{ 'Image of'|t('foster-checkout') ~ ' ' ~ lineItem.description }}"
-			/>
-		</figure>
-	</div>
+	{% if imageUrl or craft.checkout.options.enablePlaceholderImages %}
+		<div class="w-[70px] min-w-[70px]">
+			<figure class="rounded-lg overflow-hidden">
+				<img
+					src="{{ imageUrl ?? ('https://placehold.co/70x70?text=' ~ 'No Image'|t('foster-checkout')|replace({ ' ': '+' })) }}"
+					width="70"
+					height="70"
+					alt="{{ 'Image of'|t('foster-checkout') ~ ' ' ~ lineItem.description }}"
+				/>
+			</figure>
+		</div>
+	{% endif %}
 
 	<div class="flex justify-between items-stretch gap-4 flex-grow">
 		<div class="flex flex-col justify-between items-start gap-1">

--- a/src/templates/_components/app/line-item-checkout.twig
+++ b/src/templates/_components/app/line-item-checkout.twig
@@ -17,7 +17,7 @@
 		<div class="w-[70px] min-w-[70px]">
 			<figure class="rounded-lg overflow-hidden">
 				<img
-					src="{{ imageUrl ?? ('https://placehold.co/70x70?text=' ~ 'No Image'|t('foster-checkout')|replace({ ' ': '+' })) }}"
+					src="{{ imageUrl ?? ('https://placehold.co/70x70?text=' ~ 'No Image'|t('foster-checkout')|split(' ')|join('+')) }}"
 					width="70"
 					height="70"
 					alt="{{ 'Image of'|t('foster-checkout') ~ ' ' ~ lineItem.description }}"

--- a/src/translations/en/foster-checkout.php
+++ b/src/translations/en/foster-checkout.php
@@ -98,4 +98,5 @@ return [
 	'dateFormat' => 'n/j/y',
 	'Same as shipping address' => 'Same as shipping address',
 	'Use an address from your address book' => 'Use an address from your address book',
+	'No Image' => 'No Image',
 ];


### PR DESCRIPTION
- Adds an "enablePlaceholderImages" config value to the plugin
- Modifies line items to honor this setting when there are no preview images for a product
- Uses the translations file to define the texts in the placeholder images to allow for language translations