### PR TITLE
Add settings for showing and customising made a mistake section on or…

### DIFF
--- a/src/config.php
+++ b/src/config.php
@@ -40,6 +40,10 @@ return [
 		// Whether or not to enable CSS page transitions
 		//(see https://developer.mozilla.org/en-US/docs/Web/API/View_Transitions_API#browser_compatibility for browser compatibility)
 		'enablePageTransitions' => false,
+
+		// Whether or not to show the "Made a mistake" function on the order completed page
+		// If disabled then the heading and text will not be displayed
+		'enableMadeAMistake' => false,
 	],
 	// Branding Settings
 	'branding' => [
@@ -124,6 +128,14 @@ return [
 			'fieldHandle' => '',
 		],
 		'order' => [
+			'elementHandle' => '',
+			'fieldHandle' => '',
+		],
+		'mistakeHeading' => [
+			'elementHandle' => '',
+			'fieldHandle' => '',
+		],
+		'mistakeText' => [
 			'elementHandle' => '',
 			'fieldHandle' => '',
 		],

--- a/src/templates/checkout/order.twig
+++ b/src/templates/checkout/order.twig
@@ -91,16 +91,16 @@
 
 			</div>
 
+			{% if craft.fostercheckout.getOption('enableMadeAMistake') %}
 			<div class="hidden lg:block">
-				<h3 class="font-semibold text-2xl">Made a mistake?</h3>
+				<h3 class="font-semibold text-2xl">{{ craft.checkout.note('madeAMistakeHeading') | default('Made a mistake?') }}</h3>
 				<div class="mt-6 space-y-2 text-gray-500">
-					<p>
+					{{ craft.checkout.note('madeAMistakeMessage') | default('<p>
 						If you have placed an order for the wrong item or something similar, you can cancel your order
-						by clicking
-						“Review or Cancel Your Order”. Orders are processed quickly, so please cancel your order as soon
-						as possible
-						after placement. Most orders can be canceled within one hour of placement.
-					</p>
+						by clicking “Review or Cancel Your Order”. Orders are processed quickly, so please cancel your order as soon
+						as possible after placement. Most orders can be canceled within one hour of placement.
+					</p>') | raw }}
+
 				</div>
 
 				<div class="flex justify-start items-start gap-6 mt-8">
@@ -117,7 +117,7 @@
 					</form>
 				</div>
 			</div>
-
+			{% endif %}
 		</main>
 
 		<aside>


### PR DESCRIPTION
Add settings for showing and customising made a mistake section on order confirmation

Adds config settings options for

- Enable "made a mistake" section
- Made a mistake heading field
- Made a mistake text field

If enabled (default), will show the content from the Made a Mistake heading and text fields if present. If not present it will show the default heading and message.

If disabled then the Made a Mistake section is not displayed at all.