### PR TITLE
feat: updateQty should only be called when qty is defined

### DIFF
--- a/src/web/assets/checkout/dist/js/app.js
+++ b/src/web/assets/checkout/dist/js/app.js
@@ -97,7 +97,9 @@ const LineItem = (props) => {
 		sending: false,
 		input() {
 			this.qty = this.qty.replace(/\D/g, '');
-			this.updateQty();
+			if(this.qty) {
+				this.updateQty();
+			}
 		},
 		increment() {
 			this.removeMessages();


### PR DESCRIPTION
Fixes [🐞🍰 Prevent accidentally deleting a line item from the cart when trying to change its quantity by typing](https://3.basecamp.com/3091851/buckets/26456130/todos/7967082159/edit?replace=true)