### PR TITLE
Check for shipping method description before trying to output it

### DIFF
--- a/src/templates/checkout/shipping.twig
+++ b/src/templates/checkout/shipping.twig
@@ -88,8 +88,11 @@
 													>
 														<span class="block">
 															<span class="block">{{ method.name }}</span>
-															<span
-															class="block mt-1 text-sm text-gray-500">{{ craft.commerce.shippingMethods.getMatchingShippingRule(cart, method).getDescription() }}</span>
+															{% set methodDescription = craft.commerce.shippingMethods.getMatchingShippingRule(cart, method).getDescription() ?? null %}
+															{% if methodDescription %}
+																<span
+																class="block mt-1 text-sm text-gray-500">{{ craft.commerce.shippingMethods.getMatchingShippingRule(cart, method).getDescription() }}</span>
+															{% endif %}
 														</span>
 													</label>
 													<span


### PR DESCRIPTION
Fixes error that happens when trying to display shipping method description if the shipping method doesn't have one.